### PR TITLE
Fix the RailsAmp.target? to work with controllers namespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ In `http://example.com/home/index.amp`:
 If you want to use the root_url as the canonical url, you should customize the codes.
 
 ```ruby
-<% if controller_name == 'home' && action_name == 'index'  %>
+<% if controller_path == 'home' && action_name == 'index'  %>
   <link rel="canonical" href="<%= root_url %>" />
 <% else %>
   <link rel="canonical" href="<%= rails_amp_canonical_url %>" />

--- a/lib/rails_amp.rb
+++ b/lib/rails_amp.rb
@@ -79,8 +79,8 @@ module RailsAmp
       (key.camelcase + 'Controller').constantize
     end
 
-    def target?(controller_name, action_name)
-      target_actions = target_actions( key_to_controller(controller_name) )
+    def target?(controller_path, action_name)
+      target_actions = target_actions( key_to_controller(controller_path) )
       action_name.in?(target_actions)
     end
 
@@ -88,8 +88,8 @@ module RailsAmp
       format == default_format.to_s
     end
 
-    def amp_renderable?(controller_name, action_name)
-      amp_format? && target?(controller_name, action_name)
+    def amp_renderable?(controller_path, action_name)
+      amp_format? && target?(controller_path, action_name)
     end
   })
 end

--- a/lib/rails_amp/overrider.rb
+++ b/lib/rails_amp/overrider.rb
@@ -5,7 +5,7 @@ module RailsAmp
     included do
       before_action do
         RailsAmp.format = request[:format]
-        if RailsAmp.amp_renderable?(controller_name, action_name)  # default_format is :amp
+        if RailsAmp.amp_renderable?(controller_path, action_name)  # default_format is :amp
           override_actions_with_rails_amp
         end
       end

--- a/lib/rails_amp/view_helpers/action_view.rb
+++ b/lib/rails_amp/view_helpers/action_view.rb
@@ -4,11 +4,11 @@ module RailsAmp
 
       # To add header code in default layout like application.html.erb.
       def rails_amp_amphtml_link_tag
-        return '' unless RailsAmp.target?(controller.controller_name, controller.action_name)
+        return '' unless RailsAmp.target?(controller.controller_path, controller.action_name)
 
         amp_uri = URI.parse(request.url)
         if request.path == root_path
-          amp_path = "#{controller.controller_name}/#{controller.action_name}.#{RailsAmp.default_format}"
+          amp_path = "#{controller.controller_path}/#{controller.action_name}.#{RailsAmp.default_format}"
         else
           amp_path = ".#{RailsAmp.default_format}"
         end
@@ -66,7 +66,7 @@ EOS
       end
 
       def amp_renderable?
-        RailsAmp.amp_renderable?(controller.controller_name, controller.action_name)
+        RailsAmp.amp_renderable?(controller.controller_path, controller.action_name)
       end
 
       ::ActionView::Base.send :include, self

--- a/lib/rails_amp/view_helpers/image_tag_helper.rb
+++ b/lib/rails_amp/view_helpers/image_tag_helper.rb
@@ -32,7 +32,7 @@ module RailsAmp
 
       # override image_tag helper in ActionView::Helpers::AssetTagHelper
       def image_tag(source, options={})
-        if controller && RailsAmp.amp_renderable?(controller.controller_name, controller.action_name)
+        if controller && RailsAmp.amp_renderable?(controller.controller_path, controller.action_name)
           amp_image_tag(source, options)
         else
           super

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -121,3 +121,113 @@ describe HomeController do
     end
   end
 end
+
+describe Admin::SessionsController do
+  # Admin::SessionsController#index is not available for amp.
+  it 'does not return amphtml link tag' do
+    get 'index'
+    expect(rails_amp_amphtml_link_tag).to eq ''
+  end
+
+  context 'with html format' do
+    it 'is not renderable by amp' do
+      get 'index'
+      expect(amp_renderable?).to eq false
+    end
+  end
+
+  context 'with amp format' do
+    it 'is not renderable by amp' do
+      expect do
+        get 'index', format: RailsAmp.default_format.to_s
+      end.to raise_error(StandardError) # ActionView::MissingTemplate or ActionController::UnknownFormat
+    end
+  end
+end
+
+describe Admin::UsersController do
+  render_views
+
+  context '#index GET' do
+    # Admin::Users#index is available for amp.
+    it 'has correct amphtml link tag' do
+      get 'index'
+      expect(rails_amp_amphtml_link_tag).to eq(
+        %(<link rel="amphtml" href="#{request.base_url}/admin/users.#{RailsAmp.default_format}" />)
+      )
+      expect(response.body).to include(
+        %(<link rel="amphtml" href="#{request.base_url}/admin/users.#{RailsAmp.default_format}" />)
+      )
+    end
+
+    it 'has correct amphtml link tag with params' do
+      get 'index', params: { sort: 'name' }
+      expect(rails_amp_amphtml_link_tag).to eq(
+        %(<link rel="amphtml" href="#{request.base_url}/admin/users.#{RailsAmp.default_format}?sort=name" />)
+      )
+      expect(response.body).to include(
+        %(<link rel="amphtml" href="#{request.base_url}/admin/users.#{RailsAmp.default_format}?sort=name" />)
+      )
+    end
+
+    it 'has correct canonical url' do
+      get 'index', format: RailsAmp.default_format.to_s
+      expect(request.url).to eq("#{request.base_url}/admin/users.#{RailsAmp.default_format}")
+      expect(rails_amp_canonical_url).to eq("#{request.base_url}/admin/users")
+      expect(response.body).to include(
+        %(<link rel="canonical" href="#{request.base_url}/admin/users" />)
+      )
+    end
+
+    it 'has correct canonical url with params' do
+      get 'index', format: RailsAmp.default_format.to_s, params: { sort: 'name' }
+      expect(request.url).to eq("#{request.base_url}/admin/users.#{RailsAmp.default_format}?sort=name")
+      expect(rails_amp_canonical_url).to eq("#{request.base_url}/admin/users?sort=name")
+      expect(response.body).to include(
+        %(<link rel="canonical" href="#{request.base_url}/admin/users?sort=name" />)
+      )
+    end
+
+    context 'with html format' do
+      it 'is not renderable by amp' do
+        get 'index'
+        expect(amp_renderable?).to eq false
+      end
+
+      it 'has normal image tag' do
+        get 'index'
+        expect(image_tag('rails.png', size: '30x20', border: '0')).to match(
+          %r{(<img border="0" src="/(images|assets)/rails-?\w*?.png" alt="Rails" width="30" height="20" />)|(<img alt="Rails" border="0" height="20" src="/(images|assets)/rails-?\w*?.png" width="30" />)}
+        )
+        expect(image_tag('rails.png')).to match(
+          %r{(<img src="/(images|assets)/rails-?\w*?.png" alt="Rails" />)|(<img alt="Rails" src="/(images|assets)/rails-?\w*?.png" />)}
+        )
+        # According to dummy app default view `home/_amp_info`
+        expect(response.body).to match(
+          %r{(<img border="0" src="/(images|assets)/rails-?\w*?.png" alt="Rails" width="30" height="20" />)|(<img alt="Rails" border="0" height="20" src="/(images|assets)/rails-?\w*?.png" width="30" />)}
+        )
+      end
+    end
+
+    context 'with amp format' do
+      it 'is renderable by amp' do
+        get 'index', format: RailsAmp.default_format.to_s
+        expect(amp_renderable?).to eq true
+      end
+
+      it 'has amp-img tag' do
+        get 'index', format: RailsAmp.default_format.to_s
+        expect(image_tag('rails.png', size: '30x20', border: '0')).to match(
+          %r{(<amp-img src="/(images|assets)/rails-?\w*?.png" alt="Rails" width="30" height="20" layout="fixed" /></amp-img>)|(<amp-img alt="Rails" height="20" layout="fixed" src="/(images|assets)/rails-?\w*?.png" width="30" /></amp-img>)}
+        )
+        expect(image_tag('rails.png')).to match(
+          %r{(<amp-img src="/(images|assets)/rails-?\w*?.png" alt="Rails" width="50" height="64" layout="fixed" /></amp-img>)|(<amp-img alt="Rails" height="64" layout="fixed" src="/(images|assets)/rails-?\w*?.png" width="50" /></amp-img>)}
+        )
+        # According to dummy app default view `home/_amp_info`
+        expect(response.body).to match(
+          %r{(<amp-img src="/(images|assets)/rails-?\w*?.png" alt="Rails" width="30" height="20" layout="fixed" /></amp-img>)|(<amp-img alt="Rails" height="20" layout="fixed" src="/(images|assets)/rails-?\w*?.png" width="30" /></amp-img>)}
+        )
+      end
+    end
+  end
+end

--- a/spec/dummy/app/controllers/admin/sessions_controller.rb
+++ b/spec/dummy/app/controllers/admin/sessions_controller.rb
@@ -1,0 +1,7 @@
+# Just for test.
+module Admin
+  class SessionsController < ApplicationController
+    def index
+    end
+  end
+end

--- a/spec/dummy/app/controllers/admin/users_controller.rb
+++ b/spec/dummy/app/controllers/admin/users_controller.rb
@@ -1,0 +1,25 @@
+# Just for test.
+module Admin
+  class UsersController < ::ApplicationController
+    def index
+    end
+
+    def show
+    end
+
+    def new
+    end
+
+    def create
+    end
+
+    def edit
+    end
+
+    def update
+    end
+
+    def destroy
+    end
+  end
+end

--- a/spec/dummy/app/views/admin/sessions/index.html.erb
+++ b/spec/dummy/app/views/admin/sessions/index.html.erb
@@ -1,0 +1,5 @@
+<%# Just for test. %>
+<h1>Session</h1>
+
+<%# Just for test. %>
+<%= render 'home/amp_info' %>

--- a/spec/dummy/app/views/admin/users/index.html.erb
+++ b/spec/dummy/app/views/admin/users/index.html.erb
@@ -1,0 +1,5 @@
+<%# Just for test. %>
+<h1>Admin - Users List</h1>
+
+<%# Just for test. %>
+<%= render 'home/amp_info' %>

--- a/spec/dummy/app/views/admin/users/show.html.erb
+++ b/spec/dummy/app/views/admin/users/show.html.erb
@@ -1,0 +1,4 @@
+<%# Just for test. %>
+<h1>Admin - User Profile</h1>
+
+<%= render 'home/amp_info' %>

--- a/spec/dummy/config/rails_amp.yml
+++ b/spec/dummy/config/rails_amp.yml
@@ -22,7 +22,7 @@
 #
 targets:
   users: index show
-
+  admin/users: index show
 # --------------------------------------------------
 # To set initial configurations.
 # --------------------------------------------------

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -5,6 +5,9 @@ Rails.application.routes.draw do
   get '/home/index', to: 'home#index'
   get '/home/help',  to: 'home#help'
   get '/home/about', to: 'home#about'
-
+  namespace :admin do
+    resources :sessions
+    resources :users, :only => [:index, :show]
+  end
   resources :users, :only => [:index, :show]
 end

--- a/spec/rails_amp_spec.rb
+++ b/spec/rails_amp_spec.rb
@@ -10,13 +10,14 @@ describe RailsAmp do
     expect(RailsAmp.controller_to_key(HomeController)).to eq 'home'
     expect(RailsAmp.key_to_controller('users')).to eq UsersController
     expect(RailsAmp.key_to_controller('home')).to eq HomeController
+    expect(RailsAmp.key_to_controller('admin/users')).to eq Admin::UsersController
   end
 
   describe Config do
     it 'returns correct config default values' do
       expect(RailsAmp.config_file).to eq "#{Rails.root}/config/rails_amp.yml"
       expect(RailsAmp.default_format).to eq :amp
-      expect(RailsAmp.targets).to eq({ 'users' => ['index', 'show'] })
+      expect(RailsAmp.targets).to eq("users"=>["index", "show"], "admin/users"=>["index", "show"])
       expect(RailsAmp.analytics).to eq ''
     end
 
@@ -31,7 +32,7 @@ describe RailsAmp do
 
   context 'when using default /config/rails_amp.yml' do
     it 'returns correct config values' do
-      expect(RailsAmp.targets).to eq({ 'users' => ['index', 'show'] })
+      expect(RailsAmp.targets).to eq("users"=>["index", "show"], "admin/users"=>["index", "show"])
       expect(RailsAmp.target_actions(UsersController)).to eq ['index', 'show']
       expect(RailsAmp.target_actions(HomeController)).to eq []
       expect(RailsAmp.target?('users', 'index')).to eq true
@@ -39,6 +40,8 @@ describe RailsAmp do
       expect(RailsAmp.target?('home', 'index')).to eq false
       expect(RailsAmp.target?('home', 'help')).to eq false
       expect(RailsAmp.target?('home', 'about')).to eq false
+      expect(RailsAmp.target?('admin/users', 'index')).to eq true
+      expect(RailsAmp.target?('admin/sessions', 'index')).to eq false
     end
   end
 
@@ -166,6 +169,8 @@ describe RailsAmp do
       expect(RailsAmp.target?('home', 'index')).to eq true
       expect(RailsAmp.target?('home', 'help')).to eq true
       expect(RailsAmp.target?('home', 'about')).to eq true
+      expect(RailsAmp.target?('admin/users', 'index')).to eq true
+      expect(RailsAmp.target?('admin/sessions', 'index')).to eq true
     end
   end
 


### PR DESCRIPTION
This gem is not working with controllers namespace like Devise::Sessions.

This fix replaced controller_name to controller_path, e.g: session -> devise/session