### PR TITLE
Avoid to render or redirect multiple times

### DIFF
--- a/lib/rails_amp/overrider.rb
+++ b/lib/rails_amp/overrider.rb
@@ -28,7 +28,7 @@ module RailsAmp
                   format.send(RailsAmp.default_format.to_sym) do
                     # search amp format(default is .amp) .html templates
                     lookup_context.formats = [RailsAmp.default_format] + RailsAmp.lookup_formats
-                    render layout: 'rails_amp_application.amp'
+                    render layout: 'rails_amp_application.amp' unless performed?
                   end
                 end
               end

--- a/lib/rails_amp/overrider.rb
+++ b/lib/rails_amp/overrider.rb
@@ -24,11 +24,13 @@ module RailsAmp
             actions.to_a.each do |action|
               define_method action.to_sym do
                 super()
-                respond_to do |format|
-                  format.send(RailsAmp.default_format.to_sym) do
-                    # search amp format(default is .amp) .html templates
-                    lookup_context.formats = [RailsAmp.default_format] + RailsAmp.lookup_formats
-                    render layout: 'rails_amp_application.amp' unless performed?
+                unless performed?
+                  respond_to do |format|
+                    format.send(RailsAmp.default_format.to_sym) do
+                      # search amp format(default is .amp) .html templates
+                      lookup_context.formats = [RailsAmp.default_format] + RailsAmp.lookup_formats
+                      render layout: 'rails_amp_application.amp'
+                    end
                   end
                 end
               end

--- a/rails_amp.gemspec
+++ b/rails_amp.gemspec
@@ -19,5 +19,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'fastimage'
 
   s.add_development_dependency 'sqlite3'
+  s.add_development_dependency 'byebug'
   s.add_development_dependency 'rspec-rails'
 end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -94,6 +94,13 @@ describe UsersController do
         )
       end
     end
+
+    context '#redirect GET' do
+      it 'allows redirect_to or render' do
+        get 'index', params: { redirect_test: true }, format: RailsAmp.default_format.to_s
+        expect(response).to redirect_to(root_path)
+      end
+    end
   end
 end
 

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -97,7 +97,12 @@ describe UsersController do
 
     context '#redirect GET' do
       it 'allows redirect_to or render' do
-        get 'index', params: { redirect_test: true }, format: RailsAmp.default_format.to_s
+        if Gem.loaded_specs["rails"].version.to_s >= "5"
+          get 'index', params: { redirect_test: true }, format: RailsAmp.default_format.to_s
+        else
+          get 'index', redirect_test: true, format: RailsAmp.default_format.to_s
+        end
+
         expect(response).to redirect_to(root_path)
       end
     end

--- a/spec/dummy/app/controllers/users_controller.rb
+++ b/spec/dummy/app/controllers/users_controller.rb
@@ -1,7 +1,7 @@
 # Just for test.
 class UsersController < ApplicationController
   def index
-    redirect_to root_path if params['redirect_test'] == "true"
+    redirect_to root_path if params['redirect_test'].to_s == "true"
   end
 
   def show

--- a/spec/dummy/app/controllers/users_controller.rb
+++ b/spec/dummy/app/controllers/users_controller.rb
@@ -1,6 +1,7 @@
 # Just for test.
 class UsersController < ApplicationController
   def index
+    redirect_to root_path if params['redirect_test'] == "true"
   end
 
   def show


### PR DESCRIPTION
This PR fix this error:

 ```
AbstractController::DoubleRenderError (Render and/or redirect were called multiple times in this action. Please note that you may only call render OR redirect, and at most once per action. Also note that neither redirect nor render terminate execution of the action, so if you want to exit an action after redirecting, you need to do something like "redirect_to(...) and return".):
```

When tried to request a AMP page but the app redirects or render before is raising that error.

I think that the best approach is to check if render or redirect has already been called before.