### PR TITLE
add: trailing slash option to rails_amp_amphtml_link_tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,19 @@ This code will put out the html header to inform where the amp url is.
 <link rel="amphtml" href="http://example.com/users.amp" />
 ```
 
+If you need to use trailing slash option, use can use ``trailing_slash option``
+
+
+```html
+<%= rails_amp_amphtml_link_tag(trailing_slash: true) %>
+```
+
+This code will generate amp url with trailing slash.
+
+```html
+<link rel="amphtml" href="http://example.com/users.amp/" />
+```
+
 ### AMP link for root_url(root_path)
 
 When you enable amp on the controller and action for root_url, the helper `rails_amp_amphtml_link_tag` will put out the following amphtml link in the root url.

--- a/lib/rails_amp/view_helpers/action_view.rb
+++ b/lib/rails_amp/view_helpers/action_view.rb
@@ -3,7 +3,7 @@ module RailsAmp
     module ActionView
 
       # To add header code in default layout like application.html.erb.
-      def rails_amp_amphtml_link_tag
+      def rails_amp_amphtml_link_tag(options = { trailing_slash: false })
         return '' unless RailsAmp.target?(controller.controller_path, controller.action_name)
 
         amp_uri = URI.parse(request.url)
@@ -12,6 +12,7 @@ module RailsAmp
         else
           amp_path = ".#{RailsAmp.default_format}"
         end
+        amp_path += '/' if options[:trailing_slash]
         amp_uri.path = amp_uri.path + amp_path
         amp_uri.query = ERB::Util.h(amp_uri.query) if amp_uri.query.present?
 

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -73,6 +73,27 @@ describe UsersController do
         )
       end
     end
+    context '#trailing_slash GET' do
+      it 'has correct amphtml(with trailing slash) link tag' do
+        get 'trailing_slash'
+        expect(rails_amp_amphtml_link_tag(trailing_slash: true)).to eq(
+          %Q(<link rel="amphtml" href="#{request.base_url}/users/trailing_slash.#{RailsAmp.default_format.to_s}/" />)
+        )
+        expect(response.body).to include(
+          %Q(<link rel="amphtml" href="#{request.base_url}/users/trailing_slash.#{RailsAmp.default_format.to_s}/" />)
+        )
+      end
+
+      it 'has correct amphtml(with trailing slash) link tag with params' do
+        get 'trailing_slash', params: {sort: 'name'}
+        expect(rails_amp_amphtml_link_tag(trailing_slash: true)).to eq(
+          %Q(<link rel="amphtml" href="#{request.base_url}/users/trailing_slash.#{RailsAmp.default_format.to_s}/?sort=name" />)
+        )
+        expect(response.body).to include(
+          %Q(<link rel="amphtml" href="#{request.base_url}/users/trailing_slash.#{RailsAmp.default_format.to_s}/?sort=name" />)
+        )
+      end
+    end
 
     context 'with amp format' do
       it 'is renderable by amp' do

--- a/spec/dummy/app/controllers/users_controller.rb
+++ b/spec/dummy/app/controllers/users_controller.rb
@@ -7,6 +7,10 @@ class UsersController < ApplicationController
   def show
   end
 
+  def trailing_slash
+    render layout: 'trailing_slash'
+  end
+
   def new
   end
 

--- a/spec/dummy/app/views/layouts/trailing_slash.html.erb
+++ b/spec/dummy/app/views/layouts/trailing_slash.html.erb
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Dummy</title>
+    <%= csrf_meta_tags %>
+
+    <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload' %>
+    <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
+    <%= rails_amp_amphtml_link_tag(trailing_slash: true) %>
+  </head>
+
+  <body>
+    <%= yield %>
+  </body>
+</html>

--- a/spec/dummy/app/views/users/trailing_slash.html.erb
+++ b/spec/dummy/app/views/users/trailing_slash.html.erb
@@ -1,0 +1,5 @@
+<%# Just for test. %>
+<h1>Trailing Slash</h1>
+
+<%# Just for test. %>
+<%= render 'home/amp_info' %>

--- a/spec/dummy/config/rails_amp.yml
+++ b/spec/dummy/config/rails_amp.yml
@@ -21,7 +21,7 @@
 # targets:
 #
 targets:
-  users: index show
+  users: index show trailing_slash
   admin/users: index show
 # --------------------------------------------------
 # To set initial configurations.

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -9,5 +9,9 @@ Rails.application.routes.draw do
     resources :sessions
     resources :users, :only => [:index, :show]
   end
-  resources :users, :only => [:index, :show]
+  resources :users, :only => [:index, :show] do
+    collection do
+      get :trailing_slash
+    end
+  end
 end

--- a/spec/rails_amp_spec.rb
+++ b/spec/rails_amp_spec.rb
@@ -17,7 +17,7 @@ describe RailsAmp do
     it 'returns correct config default values' do
       expect(RailsAmp.config_file).to eq "#{Rails.root}/config/rails_amp.yml"
       expect(RailsAmp.default_format).to eq :amp
-      expect(RailsAmp.targets).to eq("users"=>["index", "show"], "admin/users"=>["index", "show"])
+      expect(RailsAmp.targets).to eq("users"=>["index", "show", "trailing_slash"], "admin/users"=>["index", "show"])
       expect(RailsAmp.analytics).to eq ''
     end
 
@@ -32,8 +32,8 @@ describe RailsAmp do
 
   context 'when using default /config/rails_amp.yml' do
     it 'returns correct config values' do
-      expect(RailsAmp.targets).to eq("users"=>["index", "show"], "admin/users"=>["index", "show"])
-      expect(RailsAmp.target_actions(UsersController)).to eq ['index', 'show']
+      expect(RailsAmp.targets).to eq("users"=>["index", "show", "trailing_slash"], "admin/users"=>["index", "show"])
+      expect(RailsAmp.target_actions(UsersController)).to eq ['index', 'show', 'trailing_slash']
       expect(RailsAmp.target_actions(HomeController)).to eq []
       expect(RailsAmp.target?('users', 'index')).to eq true
       expect(RailsAmp.target?('users', 'show')).to eq true
@@ -162,7 +162,7 @@ describe RailsAmp do
       expect(RailsAmp.targets).to eq({ 'application' => 'all' })
       expect(RailsAmp.disable_all?).to eq false
       expect(RailsAmp.enable_all?).to eq true
-      expect(RailsAmp.target_actions(UsersController)).to eq ['index', 'show']
+      expect(RailsAmp.target_actions(UsersController)).to match_array ['index', 'trailing_slash', 'show']
       expect(RailsAmp.target_actions(HomeController)).to eq ['index', 'help', 'about']
       expect(RailsAmp.target?('users', 'index')).to eq true
       expect(RailsAmp.target?('users', 'show')).to eq true


### PR DESCRIPTION
hi, I add trailing slash option to rails_amp_amphtml_link_tag.

The usage is written in README.md.

Please check it.

Thanks,