### PR TITLE
Add allowed class attribute to image tag

### DIFF
--- a/lib/rails_amp/view_helpers/image_tag_helper.rb
+++ b/lib/rails_amp/view_helpers/image_tag_helper.rb
@@ -4,9 +4,11 @@ module RailsAmp
   module ViewHelpers
     module ImageTagHelper
       # ref: https://www.ampproject.org/docs/reference/components/amp-img
-      AMP_IMG_PERMITTED_ATTRIBUTES = %w(
-        src srcset alt attribution height width fallback heights layout media noloading on placeholder sizes
-      )
+      AMP_IMG_PERMITTED_ATTRIBUTES = %w[
+        src srcset alt attribution height width
+        fallback heights layout media noloading on placeholder sizes
+        class
+      ].freeze
 
       # ref: https://github.com/rails/rails/blob/master/actionview/lib/action_view/helpers/asset_tag_helper.rb#L228
       def amp_image_tag(source, options={})

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -229,8 +229,8 @@ describe Admin::UsersController do
 
       it 'has amp-img tag' do
         get 'index', format: RailsAmp.default_format.to_s
-        expect(image_tag('rails.png', size: '30x20', border: '0')).to match(
-          %r{(<amp-img src="/(images|assets)/rails-?\w*?.png" alt="Rails" width="30" height="20" layout="fixed" /></amp-img>)|(<amp-img alt="Rails" height="20" layout="fixed" src="/(images|assets)/rails-?\w*?.png" width="30" /></amp-img>)}
+        expect(image_tag('rails.png', size: '30x20', border: '0', class: 'a_class')).to match(
+          %r{(<amp-img class="a_class" src="/(images|assets)/rails-?\w*?.png" alt="Rails" width="30" height="20" layout="fixed" /></amp-img>)|(<amp-img alt="Rails" class="a_class" height="20" layout="fixed" src="/(images|assets)/rails-?\w*?.png" width="30" /></amp-img>)}
         )
         expect(image_tag('rails.png')).to match(
           %r{(<amp-img src="/(images|assets)/rails-?\w*?.png" alt="Rails" width="50" height="64" layout="fixed" /></amp-img>)|(<amp-img alt="Rails" height="64" layout="fixed" src="/(images|assets)/rails-?\w*?.png" width="50" /></amp-img>)}


### PR DESCRIPTION
This adds the `class` attribute to the image tag helper.